### PR TITLE
Fix: pancakeswap anlytics stableswap

### DIFF
--- a/src/connectors/pancakeswap/stableswap-v0/analytics/index.js
+++ b/src/connectors/pancakeswap/stableswap-v0/analytics/index.js
@@ -64,5 +64,3 @@ module.exports = {
   main: analytics,
   url: 'https://pancakeswap.finance/farms',
 };
-
-analytics('bsc', '0xee1bcc9F1692E81A281b3a302a4b67890BA4be76');


### PR DESCRIPTION
Forgot to remove testing line in analytics.

Pancakeswap v3 is out, we should adapt to it!